### PR TITLE
feat: Implement weekly progress card in HomeDashboard

### DIFF
--- a/gym-frontend/src/pages/HomeDashboard.jsx
+++ b/gym-frontend/src/pages/HomeDashboard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useState } from "react";
-import { Menu, X, Check, Plus, HelpCircle, XCircle } from "lucide-react";
-import Card from "../components/Card";
+import { Menu, X, Check, HelpCircle, XCircle } from "lucide-react"; // Removed Plus
+import Card, { CardContent, CardHeader, CardTitle } from "../components/Card";
 import Button from "../components/Button";
 
 export default function HomeDashboard() {
@@ -9,13 +9,21 @@ export default function HomeDashboard() {
 
   const toggleMenu = () => setMenuOpen(!menuOpen);
 
-  const days = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
-  const todayIndex = new Date().getDay() - 1;
+  const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"];
+  // Adjust todayIndex: Monday = 0, ..., Sunday = 6
+  const todayIndex = (new Date().getDay() + 6) % 7; 
   const [progress, setProgress] = useState(Array(7).fill("?"));
 
-  const updateProgress = (index, status) => {
+  const handleDayClick = (index) => {
     const newProgress = [...progress];
-    newProgress[index] = status;
+    const currentStatus = newProgress[index];
+    if (currentStatus === "?") {
+      newProgress[index] = "✓";
+    } else if (currentStatus === "✓") {
+      newProgress[index] = "x";
+    } else {
+      newProgress[index] = "?";
+    }
     setProgress(newProgress);
   };
 
@@ -34,32 +42,36 @@ export default function HomeDashboard() {
       </aside>
 
       {/* Contenido principal */}
-      <div className="flex-1 p-4">
+      <div className="flex-1 p-4 flex flex-col items-center"> {/* Centering the card */}
         {/* Menú móvil */}
-        <div className="md:hidden flex justify-between items-center">
+        <div className="md:hidden flex justify-between items-center mb-4 w-full md:w-3/4 lg:w-1/2"> {/* Ensure mobile menu aligns with card width */}
           <Button onClick={toggleMenu} variant="outline">
             {menuOpen ? <X /> : <Menu />}
           </Button>
         </div>
 
-        {/* Tarjeta de progreso semanal */}
-        <Card>
-          <div className="flex justify-between items-center">
-            {days.map((day, index) => (
-              <div key={index} className="text-center">
-                <p className="font-bold">{day}</p>
-                <Button
-                  size="icon"
-                  variant="outline"
-                  onClick={() => updateProgress(index, index === todayIndex ? "✓" : "❌")}
+        <Card className="w-full md:w-3/4 lg:w-1/2 mt-8"> {/* Responsive width and top margin */}
+          <CardHeader>
+            <CardTitle>Progreso Semanal</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {days.map((day, index) => (
+                <div
+                  key={index}
+                  onClick={() => handleDayClick(index)}
+                  className={`flex items-center justify-between p-3 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                    index === todayIndex ? "bg-gray-100 dark:bg-gray-700 font-semibold" : ""
+                  }`}
                 >
-                  {progress[index] === "✓" ? <Check /> :
-                   progress[index] === "❌" ? <XCircle /> :
-                   index === todayIndex ? <Plus /> : <HelpCircle />}
-                </Button>
-              </div>
-            ))}
-          </div>
+                  <span>{day}</span>
+                  {progress[index] === "?" && <HelpCircle className="text-gray-500" />}
+                  {progress[index] === "✓" && <Check className="text-green-500" />}
+                  {progress[index] === "x" && <XCircle className="text-red-500" />}
+                </div>
+              ))}
+            </div>
+          </CardContent>
         </Card>
       </div>
     </div>


### PR DESCRIPTION
Replaces the previous content of HomeDashboard with a new centered, top-aligned weekly progress card.

Features:
- Displays the 7 days of the week (Lunes-Domingo).
- Highlights the current day.
- Each day shows a status icon: '?' (HelpCircle), '✓' (Check), or 'x' (XCircle).
- Clicking a day cycles its status: '?' -> '✓' -> 'x' -> '?'.
- Card is responsive and styled using Tailwind CSS.
- Preserves the existing sidebar functionality and mobile navigation.

The Home.jsx file, which seemed to be an older or alternative version, was not modified as HomeDashboard.jsx already included a sidebar and was a more suitable base for the requested changes.